### PR TITLE
Fix image_extension look up

### DIFF
--- a/lib/image_placeholder/middleware.rb
+++ b/lib/image_placeholder/middleware.rb
@@ -47,7 +47,7 @@ module ImagePlaceholder
     end
 
     def image?(path)
-      @image_extensions.include? File.extname(path)[1, 3]
+      @image_extensions.include? File.extname(path).downcase[1..-1]
     end
 
     def matched_size(path)


### PR DESCRIPTION
This fix two issues:

* If the image has a uppercased extension like kitten.PNG, then you need to include PNG as permitted extension too
* If the image has a jpeg extension, then it wasn't properly recognized (four characters extension)