### PR TITLE
Ruby 3 support - Replaces URI.decode with CGI.unescape

### DIFF
--- a/lib/image_placeholder/middleware.rb
+++ b/lib/image_placeholder/middleware.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'cgi'
 
 module ImagePlaceholder
   class Middleware
@@ -11,7 +12,7 @@ module ImagePlaceholder
 
     def call(env)
       status, headers, response = @app.call(env)
-      request_path = URI.decode(Rack::Request.new(env).fullpath)
+      request_path = CGI.unescape(Rack::Request.new(env).fullpath)
 
       if not_found?(status) && image?(request_path)
         serve_placeholder_image(matched_size(request_path))


### PR DESCRIPTION
`uri` removed the deprecated URI.unescape/decode: https://github.com/ruby/uri/commit/61c6a47ebf1f2726b60a2bbd70964d64e14b1f98 . 

This PR replaces the call to `URI.decode` with `CGI.unescape`.  This change was needed to get this gem working with Ruby 3.0. 